### PR TITLE
feat(vars): use debian based image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,27 @@ jobs:
       matrix:
         version:
         - jupyterhub: "1.0.0"
-          spark:      "2.4.4"
+          spark:      "2.4.5"
           hadoop:     "3.1.0"
         - jupyterhub: "1.1.0"
-          spark:      "2.4.4"
+          spark:      "2.4.5"
           hadoop:     "3.1.0"
+        - jupyterhub: "1.0.0"
+          spark:      "3.0.0-preview-rc2"
+          hadoop:     "3.2.0"
+        - jupyterhub: "1.0.0"
+          spark:      "3.0.0-preview2-rc2"
+          hadoop:     "3.2.0"
+        - jupyterhub: "1.1.0"
+          spark:      "3.0.0-preview-rc2"
+          hadoop:     "3.2.0"
+        - jupyterhub: "1.1.0"
+          spark:      "3.0.0-preview2-rc2"
+          hadoop:     "3.2.0"
     runs-on: ubuntu-latest
     env:
       IMAGE_NAME: spark-jupyterhub
-      SELF_VERSION: "v1"
+      SELF_VERSION: "v2"
       JUPYTERHUB_VERSION: "${{ matrix.version.jupyterhub }}"
       SPARK_VERSION: "${{ matrix.version.spark }}"
       HADOOP_VERSION: "${{ matrix.version.hadoop }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG SPARK_VERSION=2.4.4
+ARG SPARK_VERSION=2.4.5
 ARG HADOOP_VERSION=3.1.0
 
 # Note k8s based images are always officially Alpine-based
@@ -28,8 +28,6 @@ RUN conda install -y -c conda-forge \
     traitlets \
     && \
     conda clean -a -y && \
-    # Required to resolve the weird jupyterhub undefined symbol: pam_strerror linking
-    apk add --no-cache binutils linux-pam-dev && \
     :
 
 # Original jupyterhub also uses the path below

--- a/templates/vars.yml
+++ b/templates/vars.yml
@@ -1,6 +1,10 @@
-self_version: "v1"
+self_version: "v2"
 
 versions:
 - jupyterhub: ['1.0.0', '1.1.0']
-  spark:      ['2.4.4']
+  spark:      ['2.4.5']
   hadoop:     ['3.1.0']
+
+- jupyterhub: ['1.0.0', '1.1.0']
+  spark:      ['3.0.0-preview-rc2', '3.0.0-preview2-rc2']
+  hadoop:     ['3.2.0']


### PR DESCRIPTION
This causes the Spark version to be 2.4.5 and above, since the base
image for those Spark versions are Debian based.