### PR TITLE
fix(setup): conda info -e instead of conda env

### DIFF
--- a/setup-conda-env
+++ b/setup-conda-env
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 function env_present {
-  conda env list | cut -d " " -f 1 | grep "${ENVNAME}" > /dev/null
+  conda info -e | cut -d " " -f 1 | grep "${ENVNAME}" > /dev/null
 }
 
 if env_present; then
@@ -54,4 +54,5 @@ conda init bash
 conda config --add channels conda-forge
 
 conda create -y -n "${ENVNAME}" nb_conda_kernels ${DEFAULT_PACKAGES}
-# Note: To remove any conda environment, run this: conda env remove -n <env>
+# Note: To remove any conda environment, run this: conda remove --name <env> --all
+


### PR DESCRIPTION
The latter is deprecated and can no longer work.