### PR TITLE
fix(eg): add SPARK_HOME for env_keep

### DIFF
--- a/examples/github/jupyterhub_config.py
+++ b/examples/github/jupyterhub_config.py
@@ -6,6 +6,7 @@ c.LocalAuthenticator.create_system_users = True
 
 # Use JupyterLab by default
 c.Spawner.default_url = '/lab'
+c.Spawner.env_keep = ['PATH', 'PYTHONPATH', 'SPARK_HOME']
 
 # These env vars will be retrieved at runtime
 # OAUTH_CALLBACK_URL: http[s]://[your-host]/hub/oauth_callback


### PR DESCRIPTION
This is to make the demonstration example work like before when doing
`pyspark` stuff.