### PR TITLE
ci(checkout): update to v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       SCALA_VERSION: "${{ matrix.version.scala }}"
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install tera-cli
       run: |-
         wget https://github.com/guangie88/tera-cli/releases/download/v0.3.0/tera_linux_amd64 -O /tmp/tera

--- a/templates/ci.yml.tmpl
+++ b/templates/ci.yml.tmpl
@@ -42,7 +42,7 @@ jobs:
       {%- endraw %}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v1
+      uses: actions/checkout@v2
     - name: Install tera-cli
       run: |-
         wget https://github.com/guangie88/tera-cli/releases/download/v0.3.0/tera_linux_amd64 -O /tmp/tera


### PR DESCRIPTION
This is mainly to force GHA to rebuild with the newer `conda` `4.8.2`.